### PR TITLE
Session user bug

### DIFF
--- a/src/Bunq.js
+++ b/src/Bunq.js
@@ -101,7 +101,7 @@ export default class Bunq implements BunqInterface {
     )
 
     const responseData = {
-      user: data.Response[2].UserCompany,
+      user: (data.Response[2].UserCompany !== undefined) ? data.Response[2].UserCompany : data.Response[2].UserPerson,
       token: data.Response[1].Token.token
     }
 


### PR DESCRIPTION
## Context
At the moment while requesting a session from the Bunq API the client always expects a "UserCompany" which is not always the case.

## What has been done
- Added a little check to the response data object where it checks if the UserCompany is there, if not it uses the UserPerson.